### PR TITLE
README for documentation site root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Documentation
+
+Welcome to the EyebouImpact documentation website. Here are some resources to get you started:
+
+- [Architecture](/Documentation/Architecture.html)
+- [Code of Conduct](/Documentation/Code-of-conduct.html)
+- [Contributing Guidelines](/Documentation/Contributing-guidelines.html)
+- [Project Charter](/Documentation/Project-charter.html)
+- [Quality Assurance](/Documentation/quality-assurance.html)
+- [License](/Documentation/license.html)


### PR DESCRIPTION
Added a README which acts as a homepage for the documentation site. For now it just includes links to the other pages.