### PR TITLE
Remove license link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,3 @@ Welcome to the EyebouImpact documentation website. Here are some resources to ge
 - [Contributing Guidelines](/Documentation/Contributing-guidelines.html)
 - [Project Charter](/Documentation/Project-charter.html)
 - [Quality Assurance](/Documentation/quality-assurance.html)
-- [License](/Documentation/license.html)


### PR DESCRIPTION
closes #11 

Removed license link because it didn't work. It's not essential to the documentation.