### PR TITLE
Inform how to report code of conduct violations

### DIFF
--- a/Code-of-conduct.md
+++ b/Code-of-conduct.md
@@ -23,3 +23,6 @@ Examples of unacceptable behavior include:
 We have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 Scope
 This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. 
+
+### How to report code of conduct violations
+If you encounter a violation of our code of conduct, please email us at support@eyebou.com


### PR DESCRIPTION
closes #16 

Adds information at the bottom of the Code of Conduct page about how to report code of conduct violations.